### PR TITLE
fix(deps): bump Newtonsoft.Json from 12.0.2 to 13.0.3

### DIFF
--- a/Celigo.ServiceManager.NetSuite.TSA/src/Celigo.ServiceManager.NetSuite.TSA.csproj
+++ b/Celigo.ServiceManager.NetSuite.TSA/src/Celigo.ServiceManager.NetSuite.TSA.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.5" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.5" />
-        <PackageReference Include="Newtonsoft.json" Version="12.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/Celigo.ServiceManager.NetSuite/src/Celigo.ServiceManager.NetSuite.csproj
+++ b/Celigo.ServiceManager.NetSuite/src/Celigo.ServiceManager.NetSuite.csproj
@@ -39,7 +39,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.2"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Resolves all open Dependabot security alerts for this repository by bumping `Newtonsoft.Json` from 12.0.2 to 13.0.3.

### Alerts Resolved
- **Dependabot Alert 99** (HIGH): Improper Handling of Exceptional Conditions in Newtonsoft.Json (`Celigo.ServiceManager.NetSuite/src`)
- **Dependabot Alert 98** (HIGH): Improper Handling of Exceptional Conditions in Newtonsoft.Json (`Celigo.ServiceManager.NetSuite.TSA/src`)

### Changes
- `Celigo.ServiceManager.NetSuite/src/Celigo.ServiceManager.NetSuite.csproj`: 12.0.2 → 13.0.3
- `Celigo.ServiceManager.NetSuite.TSA/src/Celigo.ServiceManager.NetSuite.TSA.csproj`: 12.0.2 → 13.0.3

### Validation
- `dotnet build ServiceManager.sln` — **0 errors**
- `dotnet list package --vulnerable` — **no vulnerable packages**

### Notes
- This PR supersedes existing Dependabot PRs #76 and #91 which address the same vulnerability but in separate PRs.
- Newtonsoft.Json 13.0.3 is backward-compatible with 12.x for standard serialization/deserialization use cases. Key behavioral changes from the [release notes](https://github.com/JamesNK/Newtonsoft.Json/releases):
  - `JsonReader` and `JsonSerializer` `MaxDepth` defaults to 64 (was unlimited)
  - Portable assemblies removed from NuGet package
  - Added support for `DateOnly` and `TimeOnly`

### CVE Reference
- [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr) — Improper Handling of Exceptional Conditions