### PR TITLE
Bump NetSuite Connection Guard (Decorators 1.2.2 / Client 1.2.0)

### DIFF
--- a/Celigo.ServiceManager.NetSuite.REST/src/Celigo.ServiceManager.NetSuite.REST.csproj
+++ b/Celigo.ServiceManager.NetSuite.REST/src/Celigo.ServiceManager.NetSuite.REST.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <Authors>CloudExtend.io</Authors>
     <Company>Celigo, Inc.</Company>
     <Description>REST Client for NetSuite REST API and RESTlets</Description>
@@ -16,6 +16,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>
+      v3.0.4 - bump ConnectionGuard.Decorators to 1.2.2 (mark offline/online split-route contract fix)
       v3.0.3 - version bump for package release
     </PackageReleaseNotes>
   </PropertyGroup>
@@ -29,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Abstractions" Version="1.2.0" />
-    <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Decorators" Version="1.2.1" />
+    <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Decorators" Version="1.2.2" />
   </ItemGroup>
 
 </Project>

--- a/Celigo.ServiceManager.NetSuite.REST/tests/Celigo.ServiceManager.NetSuite.REST.UnitTests.csproj
+++ b/Celigo.ServiceManager.NetSuite.REST/tests/Celigo.ServiceManager.NetSuite.REST.UnitTests.csproj
@@ -14,8 +14,8 @@
 
     <ItemGroup>
         <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Abstractions" Version="1.2.0" />
-        <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Client" Version="1.1.1" />
-        <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Decorators" Version="1.2.1" />
+        <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Client" Version="1.2.0" />
+        <PackageReference Include="Celigo.NetSuite.ConnectionGuard.Decorators" Version="1.2.2" />
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- `Celigo.NetSuite.ConnectionGuard.Decorators` 1.2.1 → 1.2.2 (src + tests)
- `Celigo.NetSuite.ConnectionGuard.Client` 1.1.1 → 1.2.0 (tests)
- `Celigo.ServiceManager.NetSuite.REST` 3.0.3 → 3.0.4

Client 1.2.0 aligns `MarkOfflineAsync`/`MarkOnlineAsync` with the Status API split routes (`POST …/status/offline`, `POST …/status/online`); recovery stays connection-wide server-side.

## Test plan
- [ ] Restore against the published 1.2.2 / 1.2.0 packages
- [ ] REST unit tests green

Made with [Cursor](https://cursor.com)